### PR TITLE
Revised exception check when reading TTS data files produced by the DMG iDRS

### DIFF
--- a/gtam_tools/io/general.py
+++ b/gtam_tools/io/general.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import re
 from pathlib import Path
 from typing import Union
@@ -64,9 +66,11 @@ def read_tts_cross_tabulation_file(fp: Union[str, Path]) -> pd.DataFrame:
 
 def _read_csv_tts_ct_data(fp: Path, row_att: str, col_att: str, skip_rows: int, **kwargs) -> pd.DataFrame:
     try:  # First try column format
-        df = pd.read_csv(fp, index_col=[row_att, col_att], skiprows=skip_rows, delim_whitespace=True, **kwargs)
-    except ValueError:  # Else try table format
-        df = pd.read_csv(fp, index_col=0, skiprows=skip_rows, **kwargs)
+        df: pd.DataFrame = pd.read_csv(
+            fp, index_col=[row_att, col_att], skiprows=skip_rows, delim_whitespace=True, engine='c', **kwargs
+        )
+    except Exception:  # Else try table format
+        df: pd.DataFrame = pd.read_csv(fp, index_col=0, skiprows=skip_rows, engine='c', **kwargs)
         df.index.name = row_att
         df.columns.name = col_att
         df = df.stack().to_frame(name='total')


### PR DESCRIPTION
Error reading TTS data files from the DMG iDRS may occur depending on the pandas version (confirmed with 1.4.x and 1.5.x, but found no issues with 2.0.x). 

Switched to a more generic `Exception` in case pandas decides to change the error type again. Using a generic exception will always force the code to try reading CSV in the iDRS "table format" if the prior "column format" read fails; code will still error out if it can't read the file using the "table format". 

Code changes also enforces the use of the C engine used by pandas to read CSV files, just in case. While alternative engines (like pyarrow) will offer better performance, files processed by this function are typically small and will run just as fast using the standard C engine. As well, pyarrow is an optional dependency and may not be installed by all users of this package.

Fixes #3